### PR TITLE
Explicitly list hostname when doing a GRANT.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,7 +32,7 @@ We have created a fabric sript in order to set up and deploy ganetimgr. It is in
 
 You will need to have fabric installed though.
 
-This scrip will connect to the specified server and try to set up ganetimgr under "/srv/ganetimgr" which will be a symlink to the actual directory.
+This script will connect to the specified server and try to set up ganetimgr under "/srv/ganetimgr" which will be a symlink to the actual directory.
 
 In general it performs the following steps:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -76,7 +76,7 @@ Create database and user::
 
     mysql> CREATE DATABASE ganetimgr CHARACTER SET utf8;
     mysql> CREATE USER 'ganetimgr'@'localhost' IDENTIFIED BY <PASSWORD>;
-    mysql> GRANT ALL PRIVILEGES ON ganetimgr.* TO 'ganetimgr';
+    mysql> GRANT ALL PRIVILEGES ON ganetimgr.* TO 'ganetimgr'@'localhost';
     mysql> flush privileges;
 
 Requirements.txt


### PR DESCRIPTION
MySQL grant would fail:

mysql> GRANT ALL PRIVILEGES ON ganetimgr.* TO 'ganetimgr';
ERROR 1133 (42000): Can't find any matching row in the user table

The correct syntax is:

mysql> GRANT ALL PRIVILEGES ON ganetimgr.* TO 'ganetimgr'@'localhost';

(or do it in one line with

GRANT ALL PRIVILEGES ON ganetimgr.* TO 'ganetimgr'@'localhost' IDENTIFIED BY '....';